### PR TITLE
fix errors when h_rt is in seconds

### DIFF
--- a/sge2slurm.py
+++ b/sge2slurm.py
@@ -218,7 +218,7 @@ def fix_resources(sge_options):
                     elif len(m) > 2:
                         error("Improper value in the minutes field")
                 elif only_seconds_m is not None:
-                    time = only_seconds_m.groups(1)
+                    time = int(only_seconds_m.group(1))
                     s = time % 60
                     time = time // 60
                     m = time % 60


### PR DESCRIPTION
* "groups" returns a tuple but we need a string so we have to use "group" (singular!)
* that string needs to be casted to an integer for the follow %-operators to work (otherwise they are seen as string formatting characters)